### PR TITLE
1.更改sql、UsedOrderVO、UsedOrderController、listAllUsedOrder.html、listAllMsg.html、listAllNotice.html

### DIFF
--- a/DO BUY (全部TABLE整理).sql
+++ b/DO BUY (全部TABLE整理).sql
@@ -670,7 +670,7 @@ CREATE TABLE UsedOrder (
     usedOrderTime DATETIME,
     usedPrice INT(6) NOT NULL CHECK (usedPrice > 0),
     usedCount INT(5) NOT NULL CHECK (usedCount > 0),
-    deliveryStatus TINYINT(5) NOT NULL DEFAULT 0,
+    deliveryStatus TINYINT(5) NOT NULL DEFAULT 5,
     receiverName VARCHAR(200) NOT NULL,
     receiverAdr VARCHAR(200) NOT NULL,
     receiverPhone VARCHAR(200) NOT NULL,

--- a/src/main/java/com/usedorder/controller/UsedOrderController.java
+++ b/src/main/java/com/usedorder/controller/UsedOrderController.java
@@ -58,11 +58,16 @@ public class UsedOrderController {
 	        usedOrderVO.setDeliveryStatus(deliveryStatus);
 	        usedOrderSvc.updateUsedOrder(usedOrderVO);
 
-	        // 发送通知消息
+	        // 發送通知消息
 	        String deliveryStatusText = getDeliveryStatusText(deliveryStatus);
 	        NoticeVO noticeVO = new NoticeVO();
 	        noticeVO.setNoticeContent("訂單號 " + usedOrderNo + " 宅配狀態更新為" + deliveryStatusText);
 	        noticeVO.setNoticeDate(new Timestamp(System.currentTimeMillis()));
+	        
+	        // 獲取 buyerNo 並設置到 noticeVO 的 memNo
+	        Integer buyerNo = usedOrderVO.getBuyerNo();
+	        noticeVO.setMemNo(buyerNo);
+
 	        noticeSvc.save(noticeVO);
 
 	        response.put("success", true);
@@ -82,7 +87,8 @@ public class UsedOrderController {
 		case 2: return "待領件"; 
 		case 3: return "已領貨"; 
 		case 4: return "已取消"; 
-		default: return "未知狀態"; } }
+		case 5: return "已付款";
+		default: return "已付款"; } }
 
 	// 去除BindingResult中某個欄位的FieldError紀錄
 	public BindingResult removeFieldError(UsedOrderVO usedOrderVO, BindingResult result, String removedFieldname) {

--- a/src/main/java/com/usedorder/model/UsedOrderVO.java
+++ b/src/main/java/com/usedorder/model/UsedOrderVO.java
@@ -54,8 +54,11 @@ public class UsedOrderVO {
                 return "已領貨";
             case 4:
                 return "已取消";
+            case 5:
+                return "已付款"; // 確保5的狀態也能直接處理
             default:
-                return "未知狀態";
+                // 預設為狀態 5 且返回 "已付款"
+                return "已付款";
         }
     }
 

--- a/src/main/resources/templates/front-end/notice/listAllNotice.html
+++ b/src/main/resources/templates/front-end/notice/listAllNotice.html
@@ -53,6 +53,12 @@
                 });
             }
         });
+        //點擊後欄位變成淺藍色
+        $(document).ready(function() {
+            $('#example tbody').on('click', 'tr', function() {
+                $(this).css('background-color', '#dff1f7'); // 將背景色改為淺藍色
+            });
+        });
     });
 </script>
 <style type="text/css">

--- a/src/main/resources/templates/front-end/usedorder/listAllUsedOrder.html
+++ b/src/main/resources/templates/front-end/usedorder/listAllUsedOrder.html
@@ -74,7 +74,8 @@
 	        type: "POST",
 	        data: {
 	            usedOrderNo: usedOrderNo,
-	            message: message
+	            message: message,
+	            buyerNo: buyerNo
 	        },
 	        success: function(response) {
 	            if (response.success) {
@@ -142,6 +143,7 @@ body {
                         <option value="2" th:selected="${usedOrderVO.deliveryStatus == 2}">待領件</option>
                         <option value="3" th:selected="${usedOrderVO.deliveryStatus == 3}">已領貨</option>
                         <option value="4" th:selected="${usedOrderVO.deliveryStatus == 4}">已取消</option>
+                        <option value="5" th:selected="${usedOrderVO.deliveryStatus == 5}">已付款</option>
                     </select>
                 </td>
                 <td th:text="${usedOrderVO.buyerNo}"></td>

--- a/src/main/resources/templates/vendor-end/msg/listAllMsg.html
+++ b/src/main/resources/templates/vendor-end/msg/listAllMsg.html
@@ -53,6 +53,12 @@
             window.location.href = "addMsg"; // 跳轉到新增訊息頁面
         });
     });
+	 //點擊後欄位變成淺藍色
+	 $(document).ready(function() {
+         $('#example tbody').on('click', 'tr', function() {
+             $(this).css('background-color', '#dff1f7'); // 將背景色改為淺藍色
+         });
+     });
 </script>
 <style type="text/css">
 .container {


### PR DESCRIPTION

1.更改了sql表，讓deliveryStatus的預設變成5:已付款，更改UsedOrderVO、UsedOrderController，讓賣家二手訂單管理的訂單狀態預設變成已付款
2.更改UsedOrderController、listAllUsedOrder.html，讓訂單在更改狀態時，能夠傳送帶有該買家會員編號的訊息給前台通知 
3.更改listAllMsg.html、listAllNotice.html，讓訊息欄位在點擊後可以變成淺藍色(但還不能更改sql表中的已讀未讀狀態)